### PR TITLE
fix: multiframe

### DIFF
--- a/aioampio/controllers/alarm_control_panels.py
+++ b/aioampio/controllers/alarm_control_panels.py
@@ -9,13 +9,15 @@ from .utils import get_entity_index
 SATEL_CTRL_CAN_ID = 0x0F002000
 
 
-def pin_to_satel(pin: str) -> bytes:
+def pin_to_satel(pin: str | None) -> bytes:
     """
     Convert a numeric string PIN (max 16 digits) to 8 bytes.
     Each digit is encoded in 4 bits (high nibble first digit, low nibble second, etc).
     The result is padded with 0xFF to 8 bytes if needed.
     This is a more compact implementation.
     """
+    if pin is None or len(pin) == 0:
+        raise ValueError("PIN cannot be empty.")
     if not (pin.isdigit() and len(pin) <= 16):
         raise ValueError("PIN must be a numeric string up to 16 digits.")
     # Convert pin digits to nibbles and pad with 0xF

--- a/aioampio/controllers/utils.py
+++ b/aioampio/controllers/utils.py
@@ -41,8 +41,9 @@ def generate_multican_payload(
 
     function_code = 0x16
     payloads: list[bytes] = []
-    # workaround for caneth issue with identical can_ids in multi-frame
-    for _ in range(len(chunks)):
+    # Pre-fill with empty frames to address the
+    # WaveShare CAN issue with missing first frames
+    for i in range(6):
         payloads.append(bytes())
     for idx, chunk in enumerate(chunks):
         # Each chunk is prefixed with [function_code, ifd]


### PR DESCRIPTION
## Pull Request Overview

This PR fixes multiframe CAN message handling by addressing timing and validation issues. The changes improve the robustness of CAN communication by pre-filling frames and enhancing input validation.

- Pre-fills CAN payloads with 6 empty frames to resolve WaveShare CAN timing issues
- Enhances PIN validation to handle None values and empty strings explicitly
